### PR TITLE
Change back ticks to quote marks

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,10 +83,10 @@ module.exports = {
         var projectName = this.readConfig('projectName');
 
         // fetch vendor and project-specific js and map
-        var projectFileJs = distFiles.filter(minimatch.filter(`**/{${projectName},vendor}*.js`, {
+        var projectFileJs = distFiles.filter(minimatch.filter('**/{${projectName},vendor}*.js', {
           matchBase: true
         }));
-        var projectFileMap = distFiles.filter(minimatch.filter(`**/{${projectName},vendor}*.map`, {
+        var projectFileMap = distFiles.filter(minimatch.filter('**/{${projectName},vendor}*.map', {
           matchBase: true
         }));
 


### PR DESCRIPTION
This changes the back ticks to quote marks so that this works on earlier versions of node. I think this fixes https://github.com/netguru/ember-cli-deploy-rollbar/issues/1.