### PR TITLE
Add didDeploy hook, that sends deploy informations to rollbar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For detailed information on what plugin hooks are and how they work, please refe
 
 - `willUpload` (inject Rollbar snippet)
 - `upload` (upload source maps)
+- `didDeploy` (send information about deploy to Rollbar)
 
 ## Configuration Options
 
@@ -93,6 +94,13 @@ Defines internal `captureUncaught` Rollbar config.
 
 *Default:* `true`
 *Alternatives:* `false`
+
+### username
+
+Rollbar `local_username` config that is displayed in Deploys section.
+
+*Default:* `unknown user`
+*Alternatives:* any string or function returning string
 
 ## Prerequisites
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var merge = require('lodash/object/merge');
 var template = require('lodash/string/template');
 var minimatch = require('minimatch');
 var FormData = require('form-data');
-var gitUsername = require('git-user-name');
 
 var BasePlugin = require('ember-cli-deploy-plugin');
 
@@ -137,25 +136,15 @@ module.exports = {
         var environment = this.readConfig('rollbarConfig').environment;
         var revision = this.readConfig('revisionKey');
         var username = this.readConfig('username');
-        var localUsername = this.readConfig('localUsername');
 
         var formData = new FormData();
-
-        username = typeof username === 'function' ? username() : username;
-        localUsername = typeof localUsername === 'function' ? localUsername() : localUsername;
 
         formData.append('access_token', accessServerToken);
         formData.append('revision', revision);
         formData.append('environment', environment);
 
         if (username) {
-          formData.append('rollbar_username', username);
-        } else {
-          if (localUsername) {
-            formData.append('local_username', localUsername);
-          } else {
-            formData.append('local_username', gitUsername());
-          }
+          formData.append('local_username', username);
         }
 
         return new RSVP.Promise(function(resolve, reject) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-deploy-plugin": "^0.2.0",
     "form-data": "^1.0.0-rc3",
-    "git-user-name": "^1.2.0",
     "glob": "^5.0.5",
     "lodash": "^3.10.1",
     "mime": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -47,12 +47,13 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-deploy-plugin": "^0.2.0",
-    "lodash": "^3.10.1",
     "form-data": "^1.0.0-rc3",
+    "git-user-name": "^1.2.0",
+    "glob": "^5.0.5",
+    "lodash": "^3.10.1",
     "mime": "^1.3.4",
     "minimatch": "^2.0.4",
-    "rsvp": "^3.0.17",
-    "glob": "^5.0.5"
+    "rsvp": "^3.0.17"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This PR resolves #10 

It adds didDeploy hook to plugin and sends deploy informations to rollbar.

Two optional fields can be set in deploy.js:
```
rollbar: {
    accessToken: 'xxxxx',
    accessServerToken: 'xxxxx',
    minifiedPrependUrl: 'xxxxx'
    username: 'rollbarUserName'
    localUsername: 'User name'
}
````
Both fields can be either strings or functions.
If none of them is set plugin will set localUsername based on user name in git settings.