### PR TITLE
Change defaultConfig so it can be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Defines internal `enabled` Rollbar config.
 
 Defines internal `environment` Rollbar config.
 
-*Default:* `production`
+*Default:* environment setting from ember-cli-deploy-build || `production`
 *Alternatives:* any other env
 
 ### captureUncaught

--- a/index.js
+++ b/index.js
@@ -32,10 +32,21 @@ module.exports = {
           return context.distDir;
         },
         environment: function(context) {
-          return context.environment || context.config.build.environment || 'production';
+          var rollbarConfig = context.config.rollbar.rollbarConfig;
+          var buildConfig = context.config.build;
+          var environment = rollbarConfig ? rollbarConfig.environment : false;
+          return environment || buildConfig.environment || 'production';
         },
-        enabled: true,
-        captureUncaught: true,
+        enabled: function(context) {
+          var rollbarConfig = context.config.rollbar.rollbarConfig;
+          var enabled = rollbarConfig ? rollbarConfig.enabled : true;
+          return enabled === false ? false : true;
+        },
+        captureUncaught: function(context) {
+          var rollbarConfig = context.config.rollbar.rollbarConfig;
+          var captureUncaught = rollbarConfig ? rollbarConfig.captureUncaught : true;
+          return captureUncaught === false ? false : true;
+        },
         integrateRollbar: true
       },
       requiredConfig: ['accessToken', 'accessServerToken', 'minifiedPrependUrl'],

--- a/index.js
+++ b/index.js
@@ -40,12 +40,12 @@ module.exports = {
         enabled: function(context) {
           var rollbarConfig = context.config.rollbar.rollbarConfig;
           var enabled = rollbarConfig ? rollbarConfig.enabled : true;
-          return enabled === false ? false : true;
+          return !(enabled === false);
         },
         captureUncaught: function(context) {
           var rollbarConfig = context.config.rollbar.rollbarConfig;
           var captureUncaught = rollbarConfig ? rollbarConfig.captureUncaught : true;
-          return captureUncaught === false ? false : true;
+          return !(captureUncaught === false);
         },
         integrateRollbar: true
       },

--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ module.exports = {
         distDir: function(context) {
           return context.distDir;
         },
-        rollbarConfig: {
-          enabled: true,
-          environment: 'production',
-          captureUncaught: true
+        environment: function(context) {
+          return context.environment || context.config.build.environment || 'production';
         },
+        enabled: true,
+        captureUncaught: true,
         integrateRollbar: true
       },
       requiredConfig: ['accessToken', 'accessServerToken', 'minifiedPrependUrl'],
@@ -45,9 +45,9 @@ module.exports = {
           // setup rollbarConfig
           var rollbarConfig = {
             accessToken: this.readConfig('accessToken'),
-            enabled: this.readConfig('rollbarConfig').enabled,
-            captureUncaught: this.readConfig('rollbarConfig').captureUncaught,
-            environment: this.readConfig('rollbarConfig').environment,
+            enabled: this.readConfig('enabled'),
+            captureUncaught: this.readConfig('captureUncaught'),
+            environment: this.readConfig('environment'),
             payload: {
               client: {
                 javascript: {
@@ -133,7 +133,7 @@ module.exports = {
 
       didDeploy: function(context) {
         var accessServerToken = this.readConfig('accessServerToken');
-        var environment = this.readConfig('rollbarConfig').environment;
+        var environment = this.readConfig('environment');
         var revision = this.readConfig('revisionKey');
         var username = this.readConfig('username');
 


### PR DESCRIPTION
This PR resolves #12 

It changes defaultConfig so `environment`, `enabled` and `captureUncaught` can be overridden in ENV.rollbar.
Additionally `environment` has fallback to setting from ember-cli-deploy-build (ENV.build.environment).

I'm not sure if `context.config.build.environment` is good way to go. IMO context.environment should return value from other package, but it's not and it looks like it hasn't been added to the context by ember-cli-deploy-build package.

What do you think about this solution?