### PR TITLE
Allow additional sourcemap files to be uploaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ Rollbar `local_username` config that is displayed in Deploys section.
 *Default:* `unknown user`
 *Alternatives:* any string or function returning string
 
+### additionalFiles
+
+Defines additional sourcemap files to be uploaded to Rollbar. Use this if you build .js files other than `projectName.js` and `vendor.js`.
+
+Set to an array of filenames excluding their extentions. For example in an app that builds `exta-functionality.js` and `additional-library.js` set to `['exta-functionality', 'additional-library']`.
+
+*Default:* `[]`
+*Alternatives:* an array of filenames without extensions
+
 ## Prerequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = {
           var captureUncaught = rollbarConfig ? rollbarConfig.captureUncaught : true;
           return !(captureUncaught === false);
         },
+        additionalFiles: [],
         integrateRollbar: true
       },
       requiredConfig: ['accessToken', 'accessServerToken', 'minifiedPrependUrl'],
@@ -92,12 +93,19 @@ module.exports = {
       upload: function(context) {
         var distFiles = this.readConfig('distFiles');
         var projectName = this.readConfig('projectName');
+        var additionalFiles = this.readConfig('additionalFiles');
+
+        var filePattern = projectName + ',vendor';
+
+        if(additionalFiles.length) {
+          filePattern += ',' + additionalFiles.join(',');
+        }
 
         // fetch vendor and project-specific js and map
-        var projectFileJs = distFiles.filter(minimatch.filter('**/{' + projectName + ',vendor}*.js', {
+        var projectFileJs = distFiles.filter(minimatch.filter('**/{' + filePattern + '}*.js', {
           matchBase: true
         }));
-        var projectFileMap = distFiles.filter(minimatch.filter('**/{' + projectName + ',vendor}*.map', {
+        var projectFileMap = distFiles.filter(minimatch.filter('**/{' + filePattern + '}*.map', {
           matchBase: true
         }));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-rollbar",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "ember-cli-deploy addon that integrates Rollbar to your index.html file and uploads source maps to Rollbar API",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
We build and deploy a fairly significant extra .js file with our app. This allowed us to upload the additional sourcemap file to rollbar also.

If you want to merge it let me know and I'll update the README for you.